### PR TITLE
sleep and throttle were a funtion of timeout making it unresponsive f…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.sagebionetworks</groupId>
 	<artifactId>worker-utilities</artifactId>
-	<version>1.0.21</version>
+	<version>1.0.22</version>
 	<repositories>
 		<repository>
 			<id>sagebionetworks-releases-local</id>
@@ -118,8 +118,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.3.2</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
…or long worker timeouts which caused PLFM-3994
